### PR TITLE
fixed window resize

### DIFF
--- a/js/dreda.js
+++ b/js/dreda.js
@@ -132,7 +132,7 @@ renderer.render(scene,camera);
 
 // resize - listener
 
-canvas.addEventListener('resize', function () {
+window.addEventListener('resize', function () {
 canvas.width  = canvas.clientWidth;
   canvas.height = canvas.clientHeight;
   renderer.setViewport(0, 0, canvas.clientWidth, canvas.clientHeight);


### PR DESCRIPTION
The eventListener was being added to the canvas. I changed it to listen on the window and everything works.  Good call on not using THREEx.
